### PR TITLE
feat: add hiburan topup page

### DIFF
--- a/src/app/hiburan/page.tsx
+++ b/src/app/hiburan/page.tsx
@@ -1,0 +1,61 @@
+import HiburanPage from '@/components/hiburan/HiburanPage';
+import PageTransition from '@/components/animations/PageTransition';
+import { Metadata } from 'next';
+import { fetchJson } from '@/lib/fetchJson';
+
+const app_name = process.env.NEXT_PUBLIC_APP_NAME;
+const app_url = process.env.NEXT_PUBLIC_BASE_URL;
+
+export const metadata: Metadata = {
+  title: `Layanan Hiburan & Streaming | ${app_name}`,
+  description: `Beli paket Netflix, VIU, dan layanan hiburan lainnya dengan harga terbaik di ${app_name}.`,
+  metadataBase: new URL(app_url ?? ''),
+  alternates: {
+    canonical: '/hiburan',
+  },
+  robots: 'index, follow',
+  openGraph: {
+    title: `Layanan Hiburan & Streaming | ${app_name}`,
+    description: `Nikmati berbagai layanan streaming populer dengan harga murah hanya di ${app_name}.`,
+    url: new URL(`${app_url ?? ''}hiburan`),
+    siteName: app_name,
+    images: [
+      {
+        url: `${process.env.NEXT_PUBLIC_OG_IMAGE}og-image-hiburan.jpg`,
+        width: 1200,
+        height: 630,
+        alt: `${app_name} Hiburan`,
+      },
+    ],
+    locale: 'id_ID',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: `Layanan Hiburan & Streaming | ${app_name}`,
+    description: `Beli paket streaming favorit Anda secara instan di ${app_name}.`,
+    images: [`${process.env.NEXT_PUBLIC_OG_IMAGE}og-image-hiburan.jpg`],
+    site: process.env.NEXT_PUBLIC_TWITER_TAG,
+  },
+};
+
+export const viewport = {
+  themeColor: '#6b21a8',
+};
+
+export default async function Hiburan() {
+  const API = process.env.NEXT_PUBLIC_API_BASE_URL ?? '';
+
+  const [json] = await Promise.all([
+    fetchJson(API + 'api/v1/entertainments?per_page=24', { headers: { Accept: 'application/json' }, next: { revalidate: 3600 } }),
+  ]);
+
+  const data = json?.data ?? {};
+  const hiburans = data.entertainment ?? [];
+
+  return (
+    <PageTransition>
+      <HiburanPage hiburans={hiburans} />
+    </PageTransition>
+  );
+}

--- a/src/components/hiburan/HiburanPage.tsx
+++ b/src/components/hiburan/HiburanPage.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { Tv, Clapperboard, Shield, Headphones, Award, Zap } from "lucide-react";
+import Wrapper from "@/components/ui/Wrapper";
+import { HiburanTopUp } from "@/components/sections/hiburan";
+import type { Hiburan } from "@/components/sections/hiburan";
+import dynamic from "next/dynamic";
+
+const Faq = dynamic(() => import("@/components/sections/Faq/Faq"), {
+  ssr: false,
+  loading: () => <div className="h-32 bg-gray-200 dark:bg-gray-800/50 animate-pulse rounded-xl" />,
+});
+const Testimonials = dynamic(() => import("@/components/sections/Testimonials/Testimonials"), {
+  ssr: false,
+  loading: () => <div className="h-32 bg-gray-200 dark:bg-gray-800/50 animate-pulse rounded-xl" />,
+});
+
+export interface HiburanPageProps {
+  hiburans: Hiburan[];
+}
+
+const FAQ_ITEMS = [
+  {
+    q: "Bagaimana cara membeli paket hiburan?",
+    a: "Pilih layanan hiburan, masukkan nomor atau akun yang diperlukan, pilih paket, lalu lakukan pembayaran. Paket akan aktif setelah pembayaran berhasil.",
+  },
+  {
+    q: "Berapa lama proses aktivasi paket?",
+    a: "Sebagian besar paket hiburan aktif secara instan. Pada kondisi tertentu, proses dapat memakan waktu hingga 5 menit.",
+  },
+  {
+    q: "Bagaimana jika paket tidak aktif?",
+    a: "Jika paket belum aktif setelah beberapa menit, hubungi tim support kami dengan menyertakan bukti transaksi untuk dibantu lebih lanjut.",
+  },
+  {
+    q: "Apakah ada biaya tambahan?",
+    a: "Harga yang tertera adalah harga final kecuali metode pembayaran tertentu yang mengenakan biaya tambahan.",
+  },
+  {
+    q: "Bisakah membeli paket untuk orang lain?",
+    a: "Tentu, Anda dapat memasukkan nomor atau akun penerima saat melakukan transaksi.",
+  },
+  {
+    q: "Bisakah transaksi dibatalkan?",
+    a: "Transaksi yang sudah berhasil dan paket telah aktif tidak dapat dibatalkan.",
+  },
+  {
+    q: "Bagaimana cara mengetahui promo?",
+    a: "Cek secara berkala halaman utama kami atau berlangganan newsletter untuk informasi promo terbaru.",
+  },
+];
+
+const testimonials = [
+  { name: 'Andi Pratama', game: 'Netflix', rating: 5, comment: 'Streaming lancar dan harga bersahabat.', avatar: 'https://images.pexels.com/photos/1239291/pexels-photo-1239291.jpeg?auto=compress&cs=tinysrgb&w=100' },
+  { name: 'Siti Rahma', game: 'VIU', rating: 5, comment: 'Proses cepat, tinggal bayar langsung aktif.', avatar: 'https://images.pexels.com/photos/774909/pexels-photo-774909.jpeg?auto=compress&cs=tinysrgb&w=100' },
+  { name: 'Bambang Setiawan', game: 'Disney+', rating: 5, comment: 'Pelayanan memuaskan dan banyak promo.', avatar: 'https://images.pexels.com/photos/1222271/pexels-photo-1222271.jpeg?auto=compress&cs=tinysrgb&w=100' }
+];
+
+const whyChooseUs = [
+  { icon: Zap, title: 'Aktivasi Cepat', description: 'Paket hiburan aktif hanya dalam hitungan detik.' },
+  { icon: Shield, title: 'Pembayaran Aman', description: 'Sistem pembayaran yang terlindungi.' },
+  { icon: Headphones, title: 'Support 24/7', description: 'Tim bantuan selalu siap melayani Anda.' },
+  { icon: Award, title: 'Harga Terbaik', description: 'Harga kompetitif dengan banyak promo menarik.' },
+];
+
+export default function HiburanPage({ hiburans }: HiburanPageProps) {
+  return (
+    <Wrapper>
+      <main aria-labelledby="hiburan-heading">
+        <section className="relative py-16 transition-colors" aria-label="Header Hiburan">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+            <div className="bg-gradient-to-r from-primary-400 to-primary-600 p-4 rounded-2xl inline-block mb-6 shadow-lg shadow-primary-500/30">
+              <div className="flex items-center justify-center gap-2 text-white">
+                <Tv className="h-8 w-8" aria-hidden="true" />
+                <Clapperboard className="h-8 w-8" aria-hidden="true" />
+              </div>
+            </div>
+            <h1 id="hiburan-heading" className="text-4xl md:text-5xl font-bold text-gray-900 dark:text-white mb-4">
+              Layanan Hiburan & Streaming
+            </h1>
+            <p className="text-gray-600 dark:text-gray-400 max-w-2xl mx-auto leading-relaxed">
+              Beli paket streaming dan hiburan favorit Anda dengan mudah, cepat, dan aman.
+            </p>
+          </div>
+        </section>
+
+        <section className="relative py-16 transition-colors" aria-labelledby="why-heading">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="text-center mb-12">
+              <h2 id="why-heading" className="text-3xl md:text-4xl font-extrabold mb-3 bg-gradient-to-r from-primary-400 to-primary-600 bg-clip-text text-transparent">
+                Kenapa Pilih Kami?
+              </h2>
+              <div className="w-24 h-1 mx-auto bg-gradient-to-r from-primary-400 to-primary-600 rounded-full mb-4"></div>
+              <p className="text-gray-600 dark:text-gray-400 max-w-xl mx-auto text-sm md:text-base">
+                Nikmati pengalaman hiburan terbaik dengan layanan kami.
+              </p>
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+              {whyChooseUs.map((item, i) => {
+                const Icon = item.icon;
+                return (
+                  <div
+                    key={i}
+                    className="bg-white dark:bg-gray-800 p-6 rounded-xl border border-gray-200 dark:border-gray-800 hover:border-primary-500/40 transition text-center shadow-sm"
+                  >
+                    <Icon className="h-8 w-8 text-primary-500 mx-auto mb-3" aria-hidden="true" />
+                    <h3 className="font-semibold text-gray-900 dark:text-white">{item.title}</h3>
+                    <p className="text-gray-600 dark:text-gray-400 text-sm">{item.description}</p>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </section>
+
+        <section className="relative py-16 transition-colors" aria-labelledby="hiburans-heading">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center mb-12">
+            <h2 id="hiburans-heading" className="text-3xl md:text-4xl font-extrabold mb-3 bg-gradient-to-r from-primary-400 to-primary-600 bg-clip-text text-transparent">
+              Pilih Layanan
+            </h2>
+            <div className="w-24 h-1 mx-auto bg-gradient-to-r from-primary-400 to-primary-600 rounded-full mb-4"></div>
+            <p className="text-gray-600 dark:text-gray-400 max-w-xl mx-auto text-sm md:text-base">
+              Temukan berbagai paket hiburan populer sesuai kebutuhan Anda.
+            </p>
+          </div>
+          <HiburanTopUp hiburans={hiburans} />
+        </section>
+
+        <section className="relative py-16 transition-colors" aria-labelledby="testi-heading">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <Testimonials
+              testimonials={testimonials}
+              title="Apa Kata Mereka"
+              subtitle="Ulasan pelanggan tentang layanan hiburan kami."
+            />
+          </div>
+        </section>
+
+        <section className="relative py-16 transition-colors" aria-labelledby="faq-heading">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <Faq
+              items={FAQ_ITEMS}
+              variant="accordion"
+              title="Pertanyaan yang Sering Diajukan"
+              subtitle="Semua yang perlu kamu tahu tentang paket hiburan."
+            />
+          </div>
+        </section>
+      </main>
+    </Wrapper>
+  );
+}

--- a/src/components/sections/hiburan/HiburanGrid.tsx
+++ b/src/components/sections/hiburan/HiburanGrid.tsx
@@ -1,0 +1,54 @@
+"use client";
+import React from "react";
+import Image from "next/image";
+import type { Hiburan } from "./types";
+
+interface HiburanGridProps {
+  hiburans: Hiburan[];
+  onSelect: (ent: Hiburan) => void;
+  isHome?: boolean;
+}
+
+export function HiburanGrid({ hiburans, onSelect, isHome }: HiburanGridProps) {
+  const shown = isHome ? hiburans.slice(0, 6) : hiburans;
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+      {shown.map((ent) => (
+        <button
+          key={ent.id}
+          onClick={() => onSelect(ent)}
+          className="relative cursor-pointer group overflow-hidden rounded-2xl
+            bg-gradient-to-b from-gray-100 to-gray-200 dark:from-gray-800/60 dark:to-gray-900/80
+            p-4 hover:shadow-lg hover:shadow-primary-500/20
+            border border-gray-300 dark:border-gray-800
+            hover:border-primary-400 dark:hover:border-primary-500/50
+            transition-all duration-300"
+        >
+          <div className="flex justify-center mb-4">
+            <div className="relative w-20 h-20">
+              <Image
+                src={ent.logo}
+                alt={ent.name}
+                fill
+                className="rounded-lg object-contain group-hover:scale-110 transition-transform duration-300"
+              />
+            </div>
+          </div>
+
+          <h3 className="text-gray-800 dark:text-white text-lg font-semibold text-center group-hover:text-primary-500 dark:group-hover:text-primary-400 transition">
+            {ent.name}
+          </h3>
+
+          {ent.description && (
+            <p className="text-gray-600 dark:text-gray-400 text-sm text-center mt-2 line-clamp-2">
+              {ent.description}
+            </p>
+          )}
+
+          <div className="absolute inset-0 rounded-2xl bg-primary-500/0 group-hover:bg-primary-500/5 transition"></div>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/sections/hiburan/HiburanModal.tsx
+++ b/src/components/sections/hiburan/HiburanModal.tsx
@@ -1,0 +1,140 @@
+"use client";
+import React, { useEffect, useId, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import Image from "next/image";
+import { Hiburan, HiburanPackage } from "./types";
+
+interface HiburanModalProps {
+  hiburan: Hiburan | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (pkg: HiburanPackage, target: string) => Promise<void> | void;
+  submitting?: boolean;
+  formErrors?: Record<string, string[]>;
+}
+
+export function HiburanModal({
+  hiburan,
+  isOpen,
+  onClose,
+  onSubmit,
+  submitting,
+  formErrors,
+}: HiburanModalProps) {
+  const [target, setTarget] = useState("");
+  const [selectedPkg, setSelectedPkg] = useState<HiburanPackage | null>(null);
+  const inputId = useId();
+
+  useEffect(() => {
+    setTarget("");
+    setSelectedPkg(null);
+  }, [hiburan]);
+
+  const handleConfirm = async () => {
+    if (!selectedPkg || !target.trim()) return;
+    await onSubmit(selectedPkg, target.trim());
+  };
+
+  if (!isOpen || !hiburan) return null;
+
+  const error = formErrors?.target?.[0];
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={`hib-modal-title-${inputId}`}
+          aria-describedby={`hib-modal-desc-${inputId}`}
+          tabIndex={-1}
+        >
+          <motion.div
+            className="absolute inset-0 bg-black/60 dark:bg-black/70 backdrop-blur-sm"
+            onClick={onClose}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            aria-hidden="true"
+          />
+
+          <motion.div
+            className="relative z-10 w-full max-w-xl rounded-2xl border border-gray-300 dark:border-primary-500/20
+                       bg-white dark:bg-gray-900 shadow-lg p-8 transition-colors"
+            initial={{ scale: 0.9, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.9, opacity: 0 }}
+            transition={{ type: "spring", stiffness: 200, damping: 25 }}
+          >
+            <div className="flex items-center justify-between mb-6">
+              <div className="flex items-center gap-4">
+                <div className="relative w-16 h-16">
+                  <Image src={hiburan.logo} alt={hiburan.name} fill className="rounded-xl object-contain" />
+                </div>
+                <div>
+                  <h3 className="text-xl font-semibold text-gray-900 dark:text-white">{hiburan.name}</h3>
+                  <p className="text-gray-500 dark:text-gray-400 text-sm">{hiburan.description}</p>
+                </div>
+              </div>
+              <button
+                onClick={onClose}
+                className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+                aria-label="Close"
+              >
+                ✕
+              </button>
+            </div>
+
+            <div className="mb-6">
+              <label htmlFor={inputId} className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                {hiburan.label}
+              </label>
+              <input
+                id={inputId}
+                value={target}
+                onChange={(e) => setTarget(e.target.value)}
+                placeholder={hiburan.placeholder}
+                className="mt-1 w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 p-3 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                aria-invalid={!!error}
+              />
+              {error && <p className="text-red-600 text-sm mt-2">{error}</p>}
+            </div>
+
+            <div className="grid grid-cols-2 gap-4 mb-6 max-h-64 overflow-y-auto pr-2">
+              {hiburan.packages.map((pkg) => (
+                <button
+                  key={pkg.id}
+                  onClick={() => setSelectedPkg(pkg)}
+                  className={`p-4 border rounded-xl text-left transition hover:border-primary-500 ${
+                    selectedPkg?.id === pkg.id
+                      ? 'border-primary-500 bg-primary-50 dark:bg-primary-500/10'
+                      : 'border-gray-300 dark:border-gray-700'
+                  }`}
+                >
+                  <p className="font-semibold text-gray-800 dark:text-white">{pkg.name}</p>
+                  <p className="text-sm text-gray-500 dark:text-gray-400">
+                    Rp {pkg.final_price.toLocaleString('id-ID')}
+                  </p>
+                </button>
+              ))}
+            </div>
+
+            <div className="flex justify-end">
+              <button
+                onClick={handleConfirm}
+                disabled={submitting || !selectedPkg || !target.trim()}
+                className="px-6 py-3 rounded-xl font-semibold text-white bg-gradient-to-r from-primary-500 to-primary-700 disabled:opacity-50"
+              >
+                {submitting ? 'Processing...' : 'Add to Cart'}
+              </button>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/sections/hiburan/HiburanTopUp.tsx
+++ b/src/components/sections/hiburan/HiburanTopUp.tsx
@@ -1,0 +1,113 @@
+"use client";
+import React, { useState } from "react";
+import { Hiburan, HiburanPackage } from "./types";
+import { useCart } from "@/contexts/CartContext";
+import { getCartToken } from "@/lib/cart/getCartToken";
+import { handleApiErrors } from "@/utils/apiErrorHandler";
+import { HiburanGrid } from "./HiburanGrid";
+import { HiburanModal } from "./HiburanModal";
+import Link from "@/components/ui/Link";
+
+export interface HiburanTopUpProps {
+  hiburans: Hiburan[];
+  isHome?: boolean;
+}
+
+export default function HiburanTopUp({ hiburans, isHome = false }: HiburanTopUpProps) {
+  const { fetchCart, fetchQuantity } = useCart();
+  const [selected, setSelected] = useState<Hiburan | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [formErrors, setFormErrors] = useState<Record<string, string[]>>({});
+
+  const handleTopUp = async (pkg: HiburanPackage, target: string) => {
+    if (!pkg || !target.trim()) return;
+    setIsProcessing(true);
+    try {
+      const token = await getCartToken();
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}api/v1/cart/add`, {
+        method: "POST",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+          "X-Cart-Token": token ?? "",
+        },
+        body: JSON.stringify({
+          purchasable_type: pkg.type,
+          purchasable_id: pkg.id,
+          target: target.trim(),
+          target_type: "phone",
+          quantity: 1,
+        }),
+      });
+
+      const json = await res.json();
+
+      if (!res.ok) {
+        const { fields } = handleApiErrors(json);
+        setFormErrors(fields || {});
+        return;
+      }
+
+      if (json.status === "success") {
+        await Promise.all([fetchCart(), fetchQuantity()]);
+        setSelected(null);
+      }
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  return (
+    <section className="py-8" aria-label="Hiburan Packages">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <HiburanGrid
+          hiburans={hiburans}
+          onSelect={(e) => {
+            setSelected(e);
+            setFormErrors({});
+          }}
+          isHome={isHome}
+        />
+      </div>
+
+      {isHome && (
+        <div className="mt-12 text-center">
+          <Link
+            href="/hiburan"
+            className="group inline-flex items-center px-10 py-4 rounded-xl font-semibold
+              text-white dark:text-white bg-gradient-to-r from-primary-500 to-primary-700
+              hover:scale-105 transition"
+            aria-label="Lihat semua produk hiburan"
+          >
+            <span className="pr-2">Lihat Semua Produk</span>
+            <svg
+              className="h-4 w-4 translate-x-0 group-hover:translate-x-1 transition-transform"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M5 12h14" />
+              <path d="m12 5 7 7-7 7" />
+            </svg>
+          </Link>
+        </div>
+      )}
+
+      <HiburanModal
+        hiburan={selected}
+        isOpen={!!selected}
+        onClose={() => setSelected(null)}
+        onSubmit={handleTopUp}
+        submitting={isProcessing}
+        formErrors={formErrors}
+      />
+    </section>
+  );
+}

--- a/src/components/sections/hiburan/index.ts
+++ b/src/components/sections/hiburan/index.ts
@@ -1,0 +1,2 @@
+export { default as HiburanTopUp } from './HiburanTopUp';
+export type { Hiburan, HiburanPackage } from './types';

--- a/src/components/sections/hiburan/types.ts
+++ b/src/components/sections/hiburan/types.ts
@@ -1,0 +1,25 @@
+export interface HiburanPackage {
+  id: string;
+  code: string;
+  name: string;
+  type: string;
+  amount: string;
+  final_price: number;
+  original_price?: number;
+  has_discount: boolean;
+  is_popular?: boolean;
+  metadata?: Record<string, unknown>;
+}
+
+export interface Hiburan {
+  id: string;
+  name: string;
+  slug: string;
+  logo: string;
+  label: string;
+  type_package: string;
+  placeholder: string;
+  description: string;
+  is_popular?: boolean;
+  packages: HiburanPackage[];
+}


### PR DESCRIPTION
## Summary
- add hiburan streaming page with metadata
- implement hiburan top up components with modal and grid
- connect hiburan topup with cart API
- rename page and components from entertainment to hiburan

## Testing
- `npm run lint` *(fails: 'isPending' is assigned a value but never used, Component definition is missing display name, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a00659215c832388dbca6ca043585c