### PR TITLE
refactor: reuse top-up modals

### DIFF
--- a/src/components/sections/Game/GameTopUp.tsx
+++ b/src/components/sections/Game/GameTopUp.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import React, { useState, useRef, useCallback, useEffect } from "react";
-import { Loader2, Package, User, Zap, Shield, X } from "lucide-react";
-import Image from "next/image";
-import Modal from "@/components/ui/Modal";
-import FormError from "@/components/ui/FormError";
+import { Loader2 } from "lucide-react";
+// use reusable modal component
+import GameModal from "./GameModal";
 import Link from "@/components/ui/Link";
 import { useCart } from "@/contexts/CartContext";
 import { getCartToken } from "@/lib/cart/getCartToken";
@@ -264,145 +263,18 @@ const GameTopUp: React.FC<GameTopUpProps> = ({
         )}
       </div>
 
-      {/* Modal */}
       {selectedGame && (
-        <Modal
-          isOpen={!!selectedGame}
+        <GameModal
+          game={selectedGame}
           onClose={() => setSelectedGame(null)}
-          containerClassName="max-w-4xl max-h-[90vh] overflow-y-auto p-0 border-gray-200 dark:border-gray-700"
-        >
-          <>
-            {/* Header */}
-            <div
-              className="flex items-center justify-between p-5 border-b bg-gray-100 border-gray-200 dark:bg-gray-800 dark:border-gray-700"
-            >
-              <div className="flex items-center gap-4">
-                <Image
-                  src={selectedGame.logo}
-                  alt={selectedGame.name}
-                  width={200}
-                  height={200}
-                  className="w-14 h-14 rounded-lg object-cover"
-                />
-                <div>
-                  <h2 className="text-xl font-bold text-gray-900 dark:text-white">{selectedGame.name}</h2>
-                  <span className="text-primary-600 dark:text-primary-400 text-sm">{selectedGame.category}</span>
-                </div>
-              </div>
-              <button
-                onClick={() => setSelectedGame(null)}
-                className="p-2 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-lg transition cursor-pointer"
-                aria-label="Close"
-              >
-                <X className="h-6 w-6 text-gray-600 dark:text-gray-400" />
-              </button>
-            </div>
-
-            {/* Content */}
-            <div className="grid lg:grid-cols-3 gap-6 p-5 custom-scrollbar">
-              {/* Package List */}
-              <div className="lg:col-span-2">
-                <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center">
-                  <Package className="h-5 w-5 mr-2 text-primary-600 dark:text-primary-400" />
-                  Pilih Paket
-                </h3>
-
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-h-96 overflow-y-auto pr-2 pt-2">
-                  {selectedGame.packages.map((pkg) => {
-                    const discount =
-                      pkg.original_price && pkg.original_price > pkg.final_price
-                        ? Math.round(((pkg.original_price - pkg.final_price) / pkg.original_price) * 100)
-                        : 0;
-                    const isSel = selectedPackage?.id === pkg.id;
-
-                    return (
-                      <button
-                        type="button"
-                        key={pkg.id}
-                        onClick={() => setSelectedPackage(pkg)}
-                        className={`
-                      relative w-full text-left p-4 rounded-xl border transition-all cursor-pointer
-                      ${
-                        isSel
-                          ? "border-primary-500 bg-gray-100 dark:bg-gray-800 shadow-md"
-                          : "border-gray-300 bg-gray-50 hover:border-primary-400 hover:shadow-sm dark:border-gray-700 dark:bg-gray-800/50 dark:hover:border-primary-400/40"
-                      }
-                    `}
-                      >
-                        {pkg.is_popular && (
-                          <span className="absolute -top-2 left-3 bg-primary-600 text-white text-xs px-2 py-1 rounded-full font-semibold">
-                            Popular
-                          </span>
-                        )}
-                        {pkg.has_discount && (
-                          <span className="absolute -top-2 right-3 bg-red-500 text-white text-xs px-2 py-1 rounded-full font-semibold">
-                            -{discount}%
-                          </span>
-                        )}
-                        <div className="text-center space-y-2">
-                          <h4 className="text-gray-900 dark:text-white font-bold">{pkg.amount}</h4>
-                          <p className="text-gray-500 dark:text-gray-400 text-sm">{pkg.name}</p>
-                          <div className="flex justify-center gap-2">
-                            <span className="text-primary-600 dark:text-primary-400 font-bold">
-                              Rp {pkg.final_price.toLocaleString()}
-                            </span>
-                            {pkg.original_price && pkg.has_discount && (
-                              <span className="text-gray-400 line-through text-xs">
-                                Rp {pkg.original_price.toLocaleString()}
-                              </span>
-                            )}
-                          </div>
-                          {pkg.metadata?.bonus && (
-                            <p className="text-green-500 dark:text-green-400 text-xs font-medium">
-                              + {pkg.metadata.bonus} Bonus
-                            </p>
-                          )}
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-
-              {/* Sidebar */}
-              <div className="lg:col-span-1 bg-gray-50 dark:bg-gray-800 rounded-xl p-5 border border-gray-200 dark:border-gray-700 h-fit">
-                <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4 flex items-center">
-                  <User className="h-5 w-5 mr-2 text-primary-600 dark:text-primary-400" />
-                  {selectedGame.label}
-                </h3>
-
-                <div className="space-y-4">
-                  <div className="relative">
-                    <input
-                      type="text"
-                      placeholder={selectedGame.placeholder}
-                      value={gameAccount}
-                      onChange={(e) => setGameAccount(e.target.value)}
-                      className="w-full p-3 border rounded-lg text-gray-900 dark:text-white bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-700 focus:outline-none focus:ring-2 focus:ring-primary-500"
-                    />
-                    <Zap className="absolute right-3 top-3 h-5 w-5 text-gray-400" />
-                  </div>
-                  {formErrors.account && <FormError errors={formErrors.account} />}
-
-                  <button
-                    onClick={handleTopUp}
-                    disabled={!selectedPackage || !gameAccount.trim() || isProcessing}
-                    className="w-full py-3 rounded-lg font-medium text-white bg-gradient-to-r from-primary-500 to-primary-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
-                  >
-                    {isProcessing ? (
-                      <>
-                        <Shield className="h-5 w-5 animate-spin" />
-                        Processing...
-                      </>
-                    ) : (
-                      "Add to Cart"
-                    )}
-                  </button>
-                </div>
-              </div>
-            </div>
-          </>
-        </Modal>
+          onSelectPackage={setSelectedPackage}
+          selectedPackage={selectedPackage}
+          gameAccount={gameAccount}
+          setGameAccount={setGameAccount}
+          onTopUp={handleTopUp}
+          isProcessing={isProcessing}
+          formError={formErrors}
+        />
       )}
     </section>
   );

--- a/src/components/sections/hiburan/HiburanTopUp.tsx
+++ b/src/components/sections/hiburan/HiburanTopUp.tsx
@@ -1,12 +1,11 @@
 "use client";
-import React, { useState, useEffect, useId } from "react";
+import React, { useState } from "react";
 import { Hiburan, HiburanPackage } from "./types";
 import { useCart } from "@/contexts/CartContext";
 import { getCartToken } from "@/lib/cart/getCartToken";
 import { handleApiErrors } from "@/utils/apiErrorHandler";
 import { HiburanGrid } from "./HiburanGrid";
-import Image from "next/image";
-import Modal from "@/components/ui/Modal";
+import { HiburanModal } from "./HiburanModal";
 import Link from "@/components/ui/Link";
 
 export interface HiburanTopUpProps {
@@ -19,20 +18,6 @@ export default function HiburanTopUp({ hiburans, isHome = false }: HiburanTopUpP
   const [selected, setSelected] = useState<Hiburan | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
   const [formErrors, setFormErrors] = useState<Record<string, string[]>>({});
-  const [target, setTarget] = useState("");
-  const [selectedPkg, setSelectedPkg] = useState<HiburanPackage | null>(null);
-  const inputId = useId();
-
-  useEffect(() => {
-    setTarget("");
-    setSelectedPkg(null);
-  }, [selected]);
-
-  const handleConfirm = async () => {
-    if (!selectedPkg || !target.trim()) return;
-    await handleTopUp(selectedPkg, target.trim());
-  };
-
   const handleTopUp = async (pkg: HiburanPackage, target: string) => {
     if (!pkg || !target.trim()) return;
     setIsProcessing(true);
@@ -115,77 +100,14 @@ export default function HiburanTopUp({ hiburans, isHome = false }: HiburanTopUpP
       )}
 
       {selected && (
-        <Modal
+        <HiburanModal
+          hiburan={selected}
           isOpen={!!selected}
           onClose={() => setSelected(null)}
-          containerClassName="max-w-xl p-8"
-          ariaLabelledby={`hib-modal-title-${inputId}`}
-        >
-          <>
-            <div className="flex items-center justify-between mb-6">
-              <div className="flex items-center gap-4">
-                <div className="relative w-16 h-16">
-                  <Image src={selected.logo} alt={selected.name} fill className="rounded-xl object-contain" />
-                </div>
-                <div>
-                  <h3 id={`hib-modal-title-${inputId}`} className="text-xl font-semibold text-gray-900 dark:text-white">
-                    {selected.name}
-                  </h3>
-                  <p className="text-gray-500 dark:text-gray-400 text-sm">{selected.description}</p>
-                </div>
-              </div>
-              <button
-                onClick={() => setSelected(null)}
-                className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
-                aria-label="Close"
-              >
-                ✕
-              </button>
-            </div>
-
-            <div className="mb-6">
-              <label htmlFor={inputId} className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                {selected.label}
-              </label>
-              <input
-                id={inputId}
-                value={target}
-                onChange={(e) => setTarget(e.target.value)}
-                placeholder={selected.placeholder}
-                className="mt-1 w-full rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 p-3 focus:outline-none focus:ring-2 focus:ring-primary-500"
-                aria-invalid={!!formErrors.target}
-              />
-              {formErrors.target && <p className="text-red-600 text-sm mt-2">{formErrors.target[0]}</p>}
-            </div>
-
-            <div className="grid grid-cols-2 gap-4 mb-6 max-h-64 overflow-y-auto pr-2">
-              {selected.packages.map((pkg) => (
-                <button
-                  key={pkg.id}
-                  onClick={() => setSelectedPkg(pkg)}
-                  className={`p-4 border rounded-xl text-left transition hover:border-primary-500 ${
-                    selectedPkg?.id === pkg.id
-                      ? "border-primary-500 bg-primary-50 dark:bg-primary-500/10"
-                      : "border-gray-300 dark:border-gray-700"
-                  }`}
-                >
-                  <p className="font-semibold text-gray-800 dark:text-white">{pkg.name}</p>
-                  <p className="text-sm text-gray-500 dark:text-gray-400">Rp {pkg.final_price.toLocaleString("id-ID")}</p>
-                </button>
-              ))}
-            </div>
-
-            <div className="flex justify-end">
-              <button
-                onClick={handleConfirm}
-                disabled={isProcessing || !selectedPkg || !target.trim()}
-                className="px-6 py-3 rounded-xl font-semibold text-white bg-gradient-to-r from-primary-500 to-primary-700 disabled:opacity-50"
-              >
-                {isProcessing ? "Processing..." : "Add to Cart"}
-              </button>
-            </div>
-          </>
-        </Modal>
+          onSubmit={handleTopUp}
+          submitting={isProcessing}
+          formErrors={formErrors}
+        />
       )}
     </section>
   );

--- a/src/components/sections/pulsa-data/PulsaTopUp.tsx
+++ b/src/components/sections/pulsa-data/PulsaTopUp.tsx
@@ -1,17 +1,12 @@
 "use client";
-import React, { useState, useMemo, useEffect, useId } from "react";
+import React, { useState } from "react";
 import { Operator, OperatorPackage } from "./types";
 import { useCart } from "@/contexts/CartContext";
 import { getCartToken } from "@/lib/cart/getCartToken";
 import { OperatorGrid } from "./OperatorGrid";
 import { handleApiErrors } from "@/utils/apiErrorHandler";
 import Link from "@/components/ui/Link";
-import PulsaModalHeader from "./PulsaModal/PulsaModalHeader";
-import PulsaModalPhoneInput from "./PulsaModal/PulsaModalPhoneInput";
-import PulsaModalTabs from "./PulsaModal/PulsaModalTabs";
-import PulsaModalPackages from "./PulsaModal/PulsaModalPackages";
-import PulsaModalFooter from "./PulsaModal/PulsaModalFooter";
-import Modal from "@/components/ui/Modal";
+import { PulsaModal } from "./PulsaModal/PulsaModal";
 
 export interface PulsaTopUpProps {
   operators: Operator[];
@@ -23,40 +18,6 @@ const PulsaTopUp: React.FC<PulsaTopUpProps> = ({ operators, isHome = false }) =>
   const [selectedOperator, setSelectedOperator] = useState<Operator | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
   const [formErrors, setFormErrors] = useState<Record<string, string[]>>({});
-  const [tab, setTab] = useState<"pulsa" | "data">("pulsa");
-  const [phone, setPhone] = useState("");
-  const [selectedPkg, setSelectedPkg] = useState<OperatorPackage | null>(null);
-  const inputId = useId();
-
-  const pulsaPackages = useMemo(
-    () => selectedOperator?.packages.filter((p) => p.type_package === "pulsa") ?? [],
-    [selectedOperator]
-  );
-  const dataPackages = useMemo(
-    () => selectedOperator?.packages.filter((p) => p.type_package === "data") ?? [],
-    [selectedOperator]
-  );
-  const currentPackages = tab === "pulsa" ? pulsaPackages : dataPackages;
-
-  useEffect(() => {
-    setPhone("");
-    setSelectedPkg(null);
-    setTab("pulsa");
-  }, [selectedOperator]);
-
-  useEffect(() => {
-    if (selectedPkg)
-      setTab(selectedPkg.type_package === "data" ? "data" : "pulsa");
-  }, [selectedPkg]);
-
-  const handleConfirm = async () => {
-    if (!selectedPkg || !phone.trim()) return;
-    await handleTopUp(selectedPkg, phone.trim());
-  };
-
-  const modalTitleId = `pulsa-modal-title-${inputId}`;
-  const modalDescId = `pulsa-modal-desc-${inputId}`;
-
   const handleTopUp = async (pkg: OperatorPackage, phone: string) => {
     if (!pkg || !phone.trim()) return;
     setIsProcessing(true);
@@ -139,38 +100,14 @@ const PulsaTopUp: React.FC<PulsaTopUpProps> = ({ operators, isHome = false }) =>
       )}
 
       {selectedOperator && (
-        <Modal
+        <PulsaModal
+          operator={selectedOperator}
           isOpen={!!selectedOperator}
           onClose={() => setSelectedOperator(null)}
-          containerClassName="max-w-xl p-8"
-          ariaLabelledby={modalTitleId}
-          ariaDescribedby={modalDescId}
-        >
-          <>
-            <div id={modalTitleId} className="sr-only">Isi Pulsa & Paket Data</div>
-            <div id={modalDescId} className="sr-only">Formulir pembelian pulsa dan paket data untuk operator terpilih.</div>
-            <PulsaModalHeader operator={selectedOperator} selectedPkg={selectedPkg} onClose={() => setSelectedOperator(null)} />
-            <PulsaModalPhoneInput
-              phone={phone}
-              setPhone={setPhone}
-              inputId={inputId}
-              formError={formErrors}
-              operator={selectedOperator}
-            />
-            <PulsaModalTabs tab={tab} setTab={setTab} />
-            <PulsaModalPackages
-              currentPackages={currentPackages}
-              selectedPkg={selectedPkg}
-              setSelectedPkg={setSelectedPkg}
-            />
-            <PulsaModalFooter
-              submitting={isProcessing}
-              selectedPkg={selectedPkg}
-              phone={phone}
-              handleConfirm={handleConfirm}
-            />
-          </>
-        </Modal>
+          onSubmit={handleTopUp}
+          submitting={isProcessing}
+          formErrors={formErrors}
+        />
       )}
     </section>
   );


### PR DESCRIPTION
## Summary
- refactor pulsa, game, and hiburan sections to use dedicated modal components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a0272177608323b9b24ce63c6065e7