### PR TITLE
refactor: consolidate api helpers

### DIFF
--- a/src/app/game-topup/page.tsx
+++ b/src/app/game-topup/page.tsx
@@ -2,7 +2,7 @@
 import GameTopUpPage from '@/components/topup/GameTopUpPage';
 import PageTransition from '@/components/animations/PageTransition';
 import { Metadata } from 'next';
-import { fetchJson } from '@/lib/fetchJson';
+import { fetchJson } from '@/lib/api/fetchJson';
 
 const app_name = process.env.NEXT_PUBLIC_APP_NAME;
 const app_url = process.env.NEXT_PUBLIC_BASE_URL;

--- a/src/app/hiburan/page.tsx
+++ b/src/app/hiburan/page.tsx
@@ -1,7 +1,7 @@
 import HiburanPage from '@/components/hiburan/HiburanPage';
 import PageTransition from '@/components/animations/PageTransition';
 import { Metadata } from 'next';
-import { fetchJson } from '@/lib/fetchJson';
+import { fetchJson } from '@/lib/api/fetchJson';
 
 const app_name = process.env.NEXT_PUBLIC_APP_NAME;
 const app_url = process.env.NEXT_PUBLIC_BASE_URL;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ import ProductGrid from "@/components/sections/Products/ProductGrid";
 import PageTransition from "@/components/animations/PageTransition";
 import Wrapper from "@/components/ui/Wrapper";
 import { normalizeSlidesPayload } from "@/lib/slide/normalize";
-import { fetchJson } from "@/lib/fetchJson";
+import { fetchJson } from "@/lib/api/fetchJson";
 import type { Slide } from "@/components/sections/Hero/slide";
 
 const app_name = process.env.NEXT_PUBLIC_APP_NAME;

--- a/src/app/pulsa-data/page.tsx
+++ b/src/app/pulsa-data/page.tsx
@@ -2,7 +2,7 @@
 import PulsaDatapage from "@/components/pulsa-data/PulsaDataPage";
 import PageTransition from "@/components/animations/PageTransition";
 import { Metadata } from "next";
-import { fetchJson } from "@/lib/fetchJson";
+import { fetchJson } from "@/lib/api/fetchJson";
 
 const app_name = process.env.NEXT_PUBLIC_APP_NAME;
 const app_url = process.env.NEXT_PUBLIC_BASE_URL;

--- a/src/components/sections/Game/GameTopUp.tsx
+++ b/src/components/sections/Game/GameTopUp.tsx
@@ -8,7 +8,7 @@ import { useCart } from "@/contexts/CartContext";
 import { getCartToken } from "@/lib/cart/getCartToken";
 import GameGrid from "./GameGrid";
 import { Game, GamePackage, GameTopUpProps, Category } from "./types";
-import { handleApiErrors } from "@/utils/apiErrorHandler";
+import { handleApiErrors } from "@/lib/api/errorHandler";
 import GameFilterBar from "./GameFilterBar";
 
 /* ---------- Debounce ---------- */

--- a/src/components/sections/hiburan/HiburanTopUp.tsx
+++ b/src/components/sections/hiburan/HiburanTopUp.tsx
@@ -3,7 +3,7 @@ import React, { useState } from "react";
 import { Hiburan, HiburanPackage } from "./types";
 import { useCart } from "@/contexts/CartContext";
 import { getCartToken } from "@/lib/cart/getCartToken";
-import { handleApiErrors } from "@/utils/apiErrorHandler";
+import { handleApiErrors } from "@/lib/api/errorHandler";
 import { HiburanGrid } from "./HiburanGrid";
 import { HiburanModal } from "./HiburanModal";
 import Link from "@/components/ui/Link";

--- a/src/components/sections/pulsa-data/PulsaTopUp.tsx
+++ b/src/components/sections/pulsa-data/PulsaTopUp.tsx
@@ -5,7 +5,7 @@ import { Operator, OperatorPackage } from "./types";
 import { useCart } from "@/contexts/CartContext";
 import { getCartToken } from "@/lib/cart/getCartToken";
 import { OperatorGrid } from "./OperatorGrid";
-import { handleApiErrors } from "@/utils/apiErrorHandler";
+import { handleApiErrors } from "@/lib/api/errorHandler";
 import Link from "@/components/ui/Link";
 
 export interface PulsaTopUpProps {

--- a/src/lib/api/errorHandler.ts
+++ b/src/lib/api/errorHandler.ts
@@ -8,13 +8,15 @@ export interface ApiError {
  * @param json Response JSON dari API
  * @returns Objek ApiError yang berisi pesan umum dan error field (jika ada).
  */
-export function handleApiErrors(json: any): ApiError {
-  if (!json) {
+export function handleApiErrors(json: unknown): ApiError {
+  if (!json || typeof json !== "object") {
     return { message: "Terjadi kesalahan yang tidak diketahui." };
   }
 
-  const message = json.message || "Terjadi kesalahan.";
-  const fields = json.errors || undefined;
+  const { message = "Terjadi kesalahan.", errors } = json as {
+    message?: string;
+    errors?: Record<string, string[]>;
+  };
 
-  return { message, fields };
+  return { message, fields: errors };
 }

--- a/src/lib/api/fetchJson.ts
+++ b/src/lib/api/fetchJson.ts
@@ -1,8 +1,8 @@
-export async function fetchJson<T = any>(url: string, options?: RequestInit): Promise<T | null> {
+export async function fetchJson<T = unknown>(url: string, options?: RequestInit): Promise<T | null> {
   try {
     const res = await fetch(url, options);
     if (!res.ok) throw new Error('Failed to fetch');
-    return await res.json();
+    return (await res.json()) as T;
   } catch (e) {
     console.error(e);
     return null;


### PR DESCRIPTION
## Summary
- centralize API utilities in `src/lib/api`
- update pages and components to use new API helpers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b2471d710c8323b01f9b9c3e913843